### PR TITLE
PCI: loongson: Fix supported link speeds for Loongson 3c19/3c29 PCIe devices proper dynamic speed negotiation.

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -1989,6 +1989,30 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL,	PCI_DEVICE_ID_INTEL_E7525_MCH,	quir
 DECLARE_PCI_FIXUP_CLASS_FINAL(PCI_VENDOR_ID_HUAWEI, 0x1610, PCI_CLASS_BRIDGE_PCI, 8, quirk_pcie_mch);
 
 /*
+ * Older steppings of the Loongson 3C6000 series incorrectly report the
+ * supported link speeds on their PCIe bridges (device IDs 3c19, 3c29) as
+ * only 2.5 GT/s, despite the upstream bus supporting speeds from 2.5 GT/s
+ * up to 16 GT/s.
+ */
+static void quirk_loongson_pci_bridge_supported_speeds(struct pci_dev *pdev)
+{
+	switch (pdev->bus->max_bus_speed) {
+	case PCIE_SPEED_16_0GT:
+		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_16_0GB;
+	case PCIE_SPEED_8_0GT:
+		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_8_0GB;
+	case PCIE_SPEED_5_0GT:
+		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_5_0GB;
+	case PCIE_SPEED_2_5GT:
+		pdev->supported_speeds |= PCI_EXP_LNKCAP2_SLS_2_5GB;
+	default:
+		break;
+	}
+}
+DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_LOONGSON, 0x3c19, quirk_loongson_secondary_bridge_supported_speeds);
+DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_LOONGSON, 0x3c29, quirk_loongson_secondary_bridge_supported_speeds);
+
+/*
  * HiSilicon KunPeng920 and KunPeng930 have devices appear as PCI but are
  * actually on the AMBA bus. These fake PCI devices can support SVA via
  * SMMU stall feature, by setting dma-can-stall for ACPI platforms.


### PR DESCRIPTION
The "Supported Link Speeds" field reported by Loongson PCIe devices 3c19 and 3c29 is incorrect, which prevents the AMDGPU driver (and potentially others) from correctly detecting the dynamic link speed capabilities of the device. As a result, the PCIe card is incorrectly identified as a GEN1-only device, even when higher speeds are supported.

This patch manually overrides the `supported_speeds` field for these devices to reflect the actual supported link speeds.

Tested-by: Lain "Fearyncess" Yang <fsf@live.com>