### PR TITLE
BACKPORT: MIPS: Loongson64: dts: fix phy-related definition of LS7A GMAC

### DIFF
--- a/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
+++ b/arch/mips/boot/dts/loongson/ls7a-pch.dtsi
@@ -199,7 +199,8 @@
 					     <13 IRQ_TYPE_LEVEL_HIGH>;
 				interrupt-names = "macirq", "eth_lpi";
 				interrupt-parent = <&pic>;
-				phy-mode = "rgmii";
+				phy-mode = "rgmii-id";
+				phy-handle = <&phy0>;
 				mdio {
 					#address-cells = <1>;
 					#size-cells = <0>;
@@ -222,7 +223,8 @@
 					     <15 IRQ_TYPE_LEVEL_HIGH>;
 				interrupt-names = "macirq", "eth_lpi";
 				interrupt-parent = <&pic>;
-				phy-mode = "rgmii";
+				phy-mode = "rgmii-id";
+				phy-handle = <&phy1>;
 				mdio {
 					#address-cells = <1>;
 					#size-cells = <0>;


### PR DESCRIPTION
Currently the LS7A GMAC device tree node lacks a proper phy-handle property pointing to the PHY node.

In addition, the phy-mode property specifies "rgmii" without any internal delay information, which means the board trace needs to add 2ns delay to the RGMII data lines; but that isn't known to happen on any Loongson board. The ACPI-based initialization codepath, which is used on LoongArch-based 3A5000 + 7A1000 hardwares, specifies "rgmii-id" phy mode, which should be the one we are using.

Add the lacking phy-handle property and set proper phy-mode.

Tested on a LS3A4000_7A1000_NUC_BOARD_V2.1 board with YT8521S PHY.


Reviewed-by: Jiaxun Yang <jiaxun.yang@flygoat.com>