### PR TITLE
FROMLIST: kbuild: install-extmod-build: do not exclude scripts/dtc/li…

### DIFF
--- a/scripts/package/install-extmod-build
+++ b/scripts/package/install-extmod-build
@@ -11,7 +11,8 @@ is_enabled() {
 
 find_in_scripts() {
 	find scripts \
-		\( -name atomic -o -name dtc -o -name kconfig -o -name package \) -prune -o \
+		\( -name atomic -o -name kconfig -o -name package -o \
+		   \( -path '*/dtc/*' -a ! -path '*/libfdt*' \) \) -prune -o \
 		! -name unifdef -a ! -name mk_elfconfig -a \( -type f -o -type l \) -print
 }
 


### PR DESCRIPTION
…bfdt/

There exists a header file in include/linux/ called libfdt.h that is just a wrapper for libfdt header file in scripts/dtc/libfdt/. This makes the headers inside libfdt copy at scripts/dtc/libfdt/ part of the kernel headers for building external modules.

Do not exclude them, otherwise modules that include <linux/libfdt.h> will fail to build externally.

Fixes: aaed5c7739be ("kbuild: slim down package for building external modules")